### PR TITLE
Miscellaneous CAM fixes

### DIFF
--- a/cli/src/orchestrate/commands/broker/machines/unassign.py
+++ b/cli/src/orchestrate/commands/broker/machines/unassign.py
@@ -73,7 +73,7 @@ Usage: orchestrate broker machines unassign <DEPLOYMENT> <MACHINE1> [ <MACHINE2>
       log.error('Expected at least one machine name.')
       return False
 
-    machine_names = arguments[1:]
+    machine_names = arguments
     deployment_name = options.deployment or options.project
 
     self.unassign(options.project, deployment_name, machine_names)

--- a/cli/src/orchestrate/systems/teradici/camapi.py
+++ b/cli/src/orchestrate/systems/teradici/camapi.py
@@ -256,11 +256,6 @@ class Machines(Namespace):
     Returns:
       A dictionary with the CAM machine details.
     """
-    # https://github.com/GoogleCloudPlatform/solutions-cloud-orchestrate/issues/35
-    # Make sure that the machine name is all lower-case, otherwise the CAM API
-    # request will fail with a 400 error. Feels like this should be handled by
-    # CAM itself in the backend.
-    name = name.lower()
     payload = dict(
         provider='gcp',
         machineName=name,

--- a/cli/src/orchestrate/systems/teradici/camapi.py
+++ b/cli/src/orchestrate/systems/teradici/camapi.py
@@ -256,6 +256,11 @@ class Machines(Namespace):
     Returns:
       A dictionary with the CAM machine details.
     """
+    # https://github.com/GoogleCloudPlatform/solutions-cloud-orchestrate/issues/35
+    # Make sure that the machine name is all lower-case, otherwise the CAM API
+    # request will fail with a 400 error. Feels like this should be handled by
+    # CAM itself in the backend.
+    name = name.lower()
     payload = dict(
         provider='gcp',
         machineName=name,


### PR DESCRIPTION
- Resolves #34: Create deployment and handle 409 errors, if any.
- Fixes #35: Fixed 400 errors when assigning machine for the first time.
- Fixes #36: Fixed unassing not having effect.