### PR TITLE
Ability to specify disk type when creating a template.

### DIFF
--- a/api/orchestrateapi/commands/templates/create.py
+++ b/api/orchestrateapi/commands/templates/create.py
@@ -247,7 +247,7 @@ def build_template_payload(template, size):
                   autoDelete=True,
                   initializeParams=dict(
                       sourceImage=source_image,
-                      diskType='pd-standard',
+                      diskType=size.disk_type,
                       diskSizeGb=disk_size,
                   ),
               ),

--- a/api/protos/orchestrate.proto
+++ b/api/protos/orchestrate.proto
@@ -244,6 +244,7 @@ message CreateTemplateRequest {
       string gpu_type = 4;
       uint64 gpu_count = 5;
       uint64 disk_size = 6;
+      string disk_type = 7;
     }
   }
 }

--- a/cli/src/orchestrate/commands/templates/create.py
+++ b/cli/src/orchestrate/commands/templates/create.py
@@ -108,6 +108,7 @@ functionality on top of GCP:
         memory=8,
         cpus=2,
         disk_size=200,
+        disk_type='pd-standard',
         gpu_type=None,
         gpu_count=1,
         )
@@ -137,12 +138,14 @@ functionality on top of GCP:
             'A size definition is a comma-separated list of size parameters.'
             ' Separate multiple size definitions with a colon using the'
             ' following format: name=NAME,memory=MEMORY,cpus=CPUS'
-            ',disk_size=DISK_SIZE,gpu_type=GPU_TYPE,gpu_count=GPU_COUNT'
-            '[:name=NAME,memory=...]. This is a convenience method to'
-            ' specify more than one size for a template. If you only need one'
-            ' size, you could either use this option or the individual options'
-            ' --cpus, --memory, --disk-size, --gpu-type and --gpu-count.'
-            ' If both methods are used, the --size option takes precedence')),
+            ',disk_size=DISK_SIZE,disk_type=DISK_TYPE,gpu_type=GPU_TYPE,'
+            'gpu_count=GPU_COUNT[:name=NAME,memory=...]. This is a convenience'
+            ' method to specify more than one size for a template. If you only'
+            ' need one size, you could either use this option or the individual'
+            ' options --cpus, --memory, --disk-size, --gpu-type and'
+            ' --gpu-count. If both methods are used, the --size option takes'
+            ' precedence')),
+        optparse.Option('--disk-type', help='Disk type. Default is %default'),
         optparse.Option('-u', '--default-size-name', help=(
             'Default size name. Applicable only when --size is specified.')),
         optparse.Option('-o', '--scopes', help=(
@@ -250,6 +253,7 @@ functionality on top of GCP:
             gpu_type=size_parameters['gpu_type'],
             gpu_count=int(size_parameters['gpu_count']),
             disk_size=int(size_parameters['disk_size']),
+            disk_type=size_parameters['disk_type'],
             )
         sizes.append(size)
       return sizes
@@ -262,5 +266,6 @@ functionality on top of GCP:
               gpu_type=options.gpu_type,
               gpu_count=int(options.gpu_count),
               disk_size=int(options.disk_size),
+              disk_type=options.disk_type,
               ),
       ]

--- a/cli/tests/orchestrate/commands/templates/test_create.py
+++ b/cli/tests/orchestrate/commands/templates/test_create.py
@@ -92,6 +92,7 @@ def test_execution_with_defaults(execute):
   assert request.template.sizes[0].cpus == defaults['cpus']
   assert request.template.sizes[0].memory == defaults['memory']
   assert request.template.sizes[0].disk_size == defaults['disk_size']
+  assert request.template.sizes[0].disk_type == defaults['disk_type']
   assert not request.template.sizes[0].gpu_type
   assert request.template.sizes[0].gpu_count == 1
   assert request.template.default_size_name == defaults['size_name']
@@ -116,6 +117,7 @@ def test_execution_with_one_custom_size(execute):
       '--cpus=11',
       '--memory=12',
       '--disk-size=13',
+      '--disk-type=pd-ssd',
       '--gpu-type=nvidia-tesla-p4-vws',
       '--gpu-count=14',
       '--size-name=user_size',
@@ -154,6 +156,7 @@ def test_execution_with_one_custom_size(execute):
   assert request.template.sizes[0].cpus == 11
   assert request.template.sizes[0].memory == 12
   assert request.template.sizes[0].disk_size == 13
+  assert request.template.sizes[0].disk_type == 'pd-ssd'
   assert request.template.sizes[0].gpu_type == 'nvidia-tesla-p4-vws'
   assert request.template.sizes[0].gpu_count == 14
   assert request.template.default_size_name == 'user_size'


### PR DESCRIPTION
Added `--disk-type=<pd-standard|pd-ssd|local-ssd>` option to `orchestrate templates create`
Resolves #16 